### PR TITLE
Bumping prettier dependency to 2.2 for TS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "plugin-error": "^1.0.1",
-    "prettier": "^2.0.0",
+    "prettier": "^2.2.0",
     "through2": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The dependency version 2.0 of prettier does not support some Typescript functionality such as template literals and Key Remapping in Mapped Types causing errors for anyone using those with this plugin. (https://prettier.io/blog/2020/11/20/2.2.0.html) 

This bump updates prettier to 2.2 which takes care of that. Tests passed. Thank you!